### PR TITLE
Make it possible to sync remote job results from command line, without having to rerun workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ For this system:
 - `EXPYRE_NCORES_PER_TASK`
 
 #### only for pytest
-- `EXPYRE_PYTEST_CLEAN`: if set, do a real cleaning of directories in pytest `test_func.py`, otherwise only a dry run
 - `EXPYRE_PYTEST_SSH`: path to ssh to use (instead of `/usr/bin/ssh`) in pytest `test_subprocess.py` (all higher level
     tests use `remsh_cmd` item for system in `config.json`
 - `EXPYRE_PYTEST_SYSTEMS`: regexp to use to filter systems from those available in `$HOME/.expyre/config.json`
@@ -210,4 +209,18 @@ Use `xpr --help` for more info.
 
 ## Code structure
 
+
 [more details coming soon]
+
+## unit testing
+
+Unit tests use `pytest`, in the `tests` subdirectory.  The only flag that's essentially required is `--basetemp`, 
+since many queuing systems won't work if you try to submit jobs from a temporary directory like `/tmp`, which
+`pytest` uses by default, because those are not shared between the head node and compute nodes.  Pass `--basetemp`
+a directory under your home directory instead.  The `--clean` flag is recommended unless you are worried that something 
+is so wrong that attempting to clean deleted jobs will delete the wrong thing.  The `EXPYRE_PYTEST_SYSTEMS` env var
+is recommended unless you want all the remote tests to run on every remote system (useful to ensure that they are working,
+but overkill if you changed functionality that's not computer or queuing system dependent). Example use:
+```
+env EXPYRE_PYTEST_SYSTEMS=tin pytest --clean --basetemp $HOME/pytest
+```

--- a/expyre/cli/cli.py
+++ b/expyre/cli/cli.py
@@ -59,23 +59,23 @@ def cli_ls(ctx, id, name, status, system, long_output):
             cols.append([])
             if long_output:
                 headers.append('name')
-                cols[-1].append(job['name'])
+                cols[-1].append(f"{job['name']}")
                 headers.append('id')
-                cols[-1].append(' ' + job['id'])
+                cols[-1].append(f"' {job['id']}")
                 headers.append('created')
-                cols[-1].append(' ' + job['creation_time'])
+                cols[-1].append(f" {job['creation_time']}")
             else:
                 headers.append('id')
-                cols[-1].append(job['id'][0:len(job['name'])+10]+'...')
+                cols[-1].append(f"{job['id'][0:len(job['name'])+10]}...")
             headers.append('stat (time)')
-            cols[-1].append(' ' + job['status'] + ' (' + job['status_time'] + ')')
+            cols[-1].append(f" {job['status']}({job['status_time']})")
             headers.append('remote_id@sys')
-            cols[-1].append(' ' + job['remote_id'] + '@' + job['system'])
+            cols[-1].append(f" {job['remote_id']}@{job['system']}")
             headers.append('remote stat')
-            cols[-1].append(' ' + job['remote_status'])
+            cols[-1].append(f" {job['remote_status']}")
             if long_output:
                 headers.append('from dir')
-                cols[-1].append(' ' + job['from_dir'])
+                cols[-1].append(" {job['from_dir']}")
 
         cols = np.asarray(cols)
         fmt = ''

--- a/expyre/cli/cli.py
+++ b/expyre/cli/cli.py
@@ -80,6 +80,23 @@ def cli_rm(ctx, id, name, status, system, yes, clean):
             sys.stderr.write('\n')
 
 
+@cli.command("sync")
+@click.option("--id", "-i", help="comma separated list of regexps for entire job id")
+@click.option("--name", "-n", help="comma separated list of regexps for entire job name")
+@click.option("--status", "-s", help="comma separated list of status values to include, or '*' for all", default='ongoing')
+@click.option("--system", "-S", help="comma separated list of regexps for entire system name")
+@click.pass_context
+def cli_sync(ctx, id, name, status, system):
+    """Sync jobs fitting criteria (at least one criterion required)
+    """
+    if status == '*':
+        status = None
+
+    jobs = _get_jobs(id=id, name=name, status=status, system=system)
+
+    ExPyRe.sync_results_ll(jobs, cli=True)
+
+
 @cli.command("db_unlock")
 @click.pass_context
 def cli_db_unlock(ctx):

--- a/expyre/cli/cli.py
+++ b/expyre/cli/cli.py
@@ -32,7 +32,7 @@ def _get_jobs(**kwargs):
 @click.option("--name", "-n", help="comma separated list of regexps for entire job name")
 @click.option("--status", "-s", help="comma separated list of status values to include")
 @click.option("--system", "-S", help="comma separated list of regexps for entire system name")
-@click.option("--long_output", "-l", is_flag=True, help="long format output")
+@click.option("--long-output", "-l", is_flag=True, help="long format output")
 @click.pass_context
 def cli_ls(ctx, id, name, status, system, long_output):
     """List jobs fitting criteria (default all jobs)

--- a/expyre/cli/cli.py
+++ b/expyre/cli/cli.py
@@ -74,7 +74,7 @@ def cli_ls(ctx, id, name, status, system, long_output):
             rows['remote_id@sys'].append(f"{job['remote_id']}@{job['system']}")
             rows['remote stat'].append(f"{job['remote_status']}")
             if long_output:
-                rows['from dir'].append("{job['from_dir']}")
+                rows['from dir'].append(f"{job['from_dir']}")
 
         d = pd.DataFrame.from_dict(rows)
         pd.set_option('display.max_rows', None)

--- a/expyre/func.py
+++ b/expyre/func.py
@@ -141,7 +141,7 @@ class ExPyRe:
             # NOTE: following loop will not match status == 'processed' because such jobs are
             # not guaranteed to have results available.  Is it a good idea to try to use those,
             # if results actually seem to be available?
-            for job in config.db.jobs(status='can_produce_results', id=re.escape(f'{name}_{arghash}_.*')):
+            for job in config.db.jobs(status='can_produce_results', id=re.escape(f'{name}_{arghash}') + '_.*'):
                 old_stage_dir = Path(job['from_dir'])
                 # this also never happen
                 if job['status'] == 'succeeded' and not (old_stage_dir / '_expyre_job_succeeded').exists():
@@ -426,7 +426,7 @@ class ExPyRe:
         if sync_all:
             job_id = None
         else:
-            job_id = self.id
+            job_id = re.escape(self.id)
 
         # sync even if already done
         if force_sync:
@@ -434,7 +434,7 @@ class ExPyRe:
         else:
             status = 'ongoing'
 
-        jobs_to_sync = list(config.db.jobs(system=self.system_name, id=re.escape(job_id), status=status))
+        jobs_to_sync = list(config.db.jobs(system=self.system_name, id=job_id, status=status))
 
         ExPyRe.sync_results_ll(jobs_to_sync, verbose=verbose)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="expyre-wfl",
     version="0.1.0b",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["click>=7.0"],
+    install_requires=["click>=7.0", "pandas"],
     entry_points="""
     [console_scripts]
     xpr=expyre.cli.cli:cli


### PR DESCRIPTION
Refactor `func.ExPyRe.sync_results()` into a form that can be called from xpr CLI.  Works, but desperately points out that `xpr ls` output should be nicer, so user can tell which jobs are in what state.