### PR TITLE
Speed up gathering of results for multiple jobs from a remote machine

### DIFF
--- a/complete_pytest
+++ b/complete_pytest
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export EXPYRE_PYTEST_SYSTEMS='(tin|mustang)'
+
+echo  "GIT VERSION " $( git describe --always --tags --dirty ) > pytest_complete_test.out 
+echo "" >> pytest_complete_test.out 
+
+rm -rf $HOME/pytest_expyre
+ssh $KMUSTANG rm -rf pytest_expyre_rundir_mustang
+pytest --clean --basetemp $HOME/pytest_expyre >> pytest_complete_test.out 2>&1
+
+l=`egrep 'passed.*xfailed' pytest_complete_test.out`
+
+echo $l | grep -q -v 'skipped'
+if [ $? != 0 ]; then
+    echo "Unexpected number skipped not 0 '$l'" 1>&2
+    exit 1
+fi
+echo $l | grep -q ' 22 passed'
+if [ $? != 0 ]; then
+    echo "Unexpected number passed not 22 '$l'" 1>&2
+    exit 1
+fi
+echo $l | grep -q ' 1 xfailed'
+if [ $? != 0 ]; then
+    echo "Unexpected number xfailed not 1 '$l'" 1>&2
+    exit 1
+fi

--- a/expyre/func.py
+++ b/expyre/func.py
@@ -72,7 +72,7 @@ class ExPyRe:
             raise RuntimeError('Configuration file was not found, ExPyRe object cannot be created')
 
         # name will be used as part of path, can't have a few special things
-        assert ('/' not in name and '[' not in name and ']' not in name and 
+        assert ('/' not in name and '[' not in name and ']' not in name and
                 '{' not in name and '}' not in name and '*' not in name and '\\' not in name)
 
         if 'EXPYRE_TIMING_VERBOSE' in os.environ:
@@ -422,7 +422,11 @@ class ExPyRe:
 
 
     def sync_remote_results_status(self, sync_all=True, force_sync=False, verbose=False):
-        """Sync files associated with results from remote machine to local stage dirs
+        """Sync files associated with results from remote machine to local stage dirs and
+        updates 'remote_status' in jobsdb.  Note that both have to happen because other
+        functions assume that if remote status has been updated files have been staged back
+        as well.
+
         Parameters
         ----------
         sync_all: bool, default True
@@ -451,7 +455,9 @@ class ExPyRe:
 
     @classmethod
     def sync_remote_results_status_ll(cls, jobs_to_sync, n_group=250, cli=False, verbose=False):
-        """Low level part of syncing jobs
+        """Low level part of syncing jobs.  Gets remote files _and_ updates 'remote_status'
+        field in jobsdb.  Note that both have to happen because other functions assume that
+        if remote status has been updated files have been staged back as well.
 
         Parameters
         ----------
@@ -462,6 +468,9 @@ class ExPyRe:
         n_group: int, default 250
             number of jobs to do in a group with each rsync call
         """
+        if len(jobs_to_sync) == 0:
+            return
+
         def _grouper(n, iterable):
             it = iter(iterable)
             while True:
@@ -470,22 +479,26 @@ class ExPyRe:
                     return
                 yield chunk
 
-        if len(jobs_to_sync) > 0:
-            for system_name in set([j['system'] for j in jobs_to_sync]):
-                system = config.systems[system_name]
-                # assume all jobs are staged from same place
-                stage_root = Path(jobs_to_sync[0]['from_dir']).parent
-                # get remote files
-                for job_group in _grouper(n_group, jobs_to_sync):
-                    system.get_remotes(stage_root, subdir_glob=[Path(j['from_dir']).name for j in job_group],
-                                       verbose=verbose)
+        for system_name in set([j['system'] for j in jobs_to_sync]):
+            system = config.systems[system_name]
+            # assume all jobs are staged from same place
+            stage_root = Path(jobs_to_sync[0]['from_dir']).parent
 
-                # get remote statuses and update in JobsDB
-                status_of_remote_id = system.scheduler.status([j['remote_id'] for j in jobs_to_sync], verbose=verbose)
-                for j in jobs_to_sync:
-                    if cli:
-                        sys.stderr.write(f'Update remote status of {j["id"]} to {status_of_remote_id[j["remote_id"]]}\n')
-                    config.db.update(j['id'], remote_status=status_of_remote_id[j['remote_id']])
+            # get remote statuses and update in JobsDB
+            status_of_remote_id = system.scheduler.status([j['remote_id'] for j in jobs_to_sync], verbose=verbose)
+            for j in jobs_to_sync:
+                if cli:
+                    sys.stderr.write(f'Update remote status of {j["id"]} to {status_of_remote_id[j["remote_id"]]}\n')
+                config.db.update(j['id'], remote_status=status_of_remote_id[j['remote_id']])
+
+            # get remote files only _AFTER_ getting remote status, since otherwise might result in
+            # a race condition:
+            #    copy files while job is running, so not all files are ready
+            #    while files are being copied, job finishes (but some files were not copied)
+            #    update status, showing job as done (despite missing files)
+            for job_group in _grouper(n_group, jobs_to_sync):
+                system.get_remotes(stage_root, subdir_glob=[Path(j['from_dir']).name for j in job_group],
+                                   verbose=verbose)
 
 
     def clean(self, wipe=False, dry_run=False, verbose=False):
@@ -582,11 +595,19 @@ class ExPyRe:
             # sync remote results and status.  This used to be inside test for status and/or succeeded/failed
             # file existence, but that's probably not useful.  If we're in this loop we have to sync, since if
             # sync isn't needed, loop should have been exited on previous iteration
-            self.sync_remote_results_status(sync_all, force_sync, verbose=verbose)
 
-            # get remote status of job from db (was set by call to self.sync_remote_results_status() just above)
-            # remote_status: queued, held,       running,    done, failed, timeout, other
+            # get remote status of job from db (either unset or was set by call to
+            #     self.sync_remote_results_status() in previous iter)
+            # remote_status values: queued, held,       running,    done, failed, timeout, other
             remote_status = list(config.db.jobs(id=re.escape(self.id)))[0]['remote_status']
+            if remote_status != 'done':
+                # If previous status was not 'done', need to sync remote status.
+                # If it was pre-done, we obviously need current state and results.
+                # If it was something else (even 'failed'), lets try again just in case it needed
+                #     more time or was fixed manually.
+                self.sync_remote_results_status(sync_all, force_sync, verbose=verbose)
+
+                remote_status = list(config.db.jobs(id=re.escape(self.id)))[0]['remote_status']
 
             # poke filesystem, since on some machines Path.exists() fails even if file appears to be there when doing ls
             _ = list(self.stage_dir.glob('_expyre_job_*'))

--- a/expyre/func.py
+++ b/expyre/func.py
@@ -487,9 +487,12 @@ class ExPyRe:
             # get remote statuses and update in JobsDB
             status_of_remote_id = system.scheduler.status([j['remote_id'] for j in jobs_to_sync], verbose=verbose)
             for j in jobs_to_sync:
-                if cli:
-                    sys.stderr.write(f'Update remote status of {j["id"]} to {status_of_remote_id[j["remote_id"]]}\n')
-                config.db.update(j['id'], remote_status=status_of_remote_id[j['remote_id']])
+                old_remote_status = list(config.db.jobs(id=j['id']))[0]['remote_status']
+                new_remote_status = status_of_remote_id[j['remote_id']]
+                if old_remote_status != new_remote_status:
+                    if cli:
+                        sys.stderr.write(f'Update remote status of {j["id"]} to {status_of_remote_id[j["remote_id"]]}\n')
+                    config.db.update(j['id'], remote_status=status_of_remote_id[j['remote_id']])
 
             # get remote files only _AFTER_ getting remote status, since otherwise might result in
             # a race condition:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import warnings
 
 import pytest
 
@@ -7,7 +8,7 @@ from pathlib import Path
 
 from expyre.resources import Resources
 
-def test_system_same_machine(tmp_path, expyre_config):
+def test_system(tmp_path, expyre_config):
     from expyre.config import systems
 
     for sys_name, system in systems.items():
@@ -25,6 +26,11 @@ def do_system(tmp_path, system, job_name):
 
     assert not (stage_dir / 'out').exists()
 
+    if system.host is not None:
+        # May need to clean up remote stage dir.
+        warnings.warn('If remote system still has stage_dir {stage_dir} from a previous run, this test will fail')
+
+    # submit job
     remote_id = system.submit(job_name, stage_dir,
                            resources=Resources(n=(2, 'nodes'), max_time='5m'),
                            commands=['pwd', 'echo BOB > out', 'sleep 20'])


### PR DESCRIPTION
Remove unneeded rsyncs by not doing it again if jobs database remote_status is already "done", because that means the remote files were already staged in earlier.

Remove race condition in gathering of remote status and staging in files.

Warn on possible problem with test_system() which will fail if remote system still has older testing directory.