### PR TITLE
get queuing system header from more places

### DIFF
--- a/expyre/func.py
+++ b/expyre/func.py
@@ -370,7 +370,7 @@ class ExPyRe:
             config.systems[self.system_name].scheduler.cancel(self.remote_id, verbose=verbose)
 
 
-    def start(self, resources, system_name=os.environ.get('EXPYRE_SYS', None), header=[],
+    def start(self, resources, system_name=os.environ.get('EXPYRE_SYS', None), header_extra=[],
               exact_fit=True, partial_node=False, python_cmd='python3'):
         """Start a job on a remote machine
         Parameters
@@ -379,7 +379,7 @@ class ExPyRe:
             resources to use for job, either Resources or dict of Resources constructor kwargs
         system_name: str
             name of system in config.systems
-        header: list(str), optional
+        header_extra: list(str), optional
             list of lines to add to queuing system header, appended to System.header[]
         exact_fit: bool, default True
             use only nodes that exactly match number of tasks
@@ -409,7 +409,7 @@ class ExPyRe:
             post_run_commands = fin.readlines()
         if 'EXPYRE_TIMING_VERBOSE' in os.environ:
             sys.stderr.write(f'ExPyRe {self.id} start() calling system.submit {time.time()}\n')
-        self.remote_id = system.submit(self.id, self.stage_dir, resources=resources, header=header,
+        self.remote_id = system.submit(self.id, self.stage_dir, resources=resources, header_extra=header_extra,
                                        commands=(pre_run_commands + [f'{python_cmd} _expyre_script_core.py'] +
                                                  post_run_commands),
                                        exact_fit=exact_fit, partial_node=partial_node)

--- a/expyre/func.py
+++ b/expyre/func.py
@@ -370,7 +370,7 @@ class ExPyRe:
             config.systems[self.system_name].scheduler.cancel(self.remote_id, verbose=verbose)
 
 
-    def start(self, resources, system_name=os.environ.get('EXPYRE_SYS', None),
+    def start(self, resources, system_name=os.environ.get('EXPYRE_SYS', None), header=[],
               exact_fit=True, partial_node=False, python_cmd='python3'):
         """Start a job on a remote machine
         Parameters
@@ -379,6 +379,8 @@ class ExPyRe:
             resources to use for job, either Resources or dict of Resources constructor kwargs
         system_name: str
             name of system in config.systems
+        header: list(str), optional
+            list of lines to add to queuing system header, appended to System.header[]
         exact_fit: bool, default True
             use only nodes that exactly match number of tasks
         partial_node: bool, default False
@@ -407,7 +409,7 @@ class ExPyRe:
             post_run_commands = fin.readlines()
         if 'EXPYRE_TIMING_VERBOSE' in os.environ:
             sys.stderr.write(f'ExPyRe {self.id} start() calling system.submit {time.time()}\n')
-        self.remote_id = system.submit(self.id, self.stage_dir, resources=resources,
+        self.remote_id = system.submit(self.id, self.stage_dir, resources=resources, header=header,
                                        commands=(pre_run_commands + [f'{python_cmd} _expyre_script_core.py'] +
                                                  post_run_commands),
                                        exact_fit=exact_fit, partial_node=partial_node)

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -79,7 +79,7 @@ class System:
         return f'{self.remote_rundir}/{stage_dir.name}'
 
 
-    def submit(self, id, stage_dir, resources, commands, exact_fit=True, partial_node=False, verbose=False):
+    def submit(self, id, stage_dir, resources, header, commands, exact_fit=True, partial_node=False, verbose=False):
         """Submit a job on a remote machine, including staging out files
 
         Parameters
@@ -88,8 +88,10 @@ class System:
             unique id for job
         stage_dir: str, Path
             directory in which files have been prepared
-        resoures: Resources
+        resources: Resources
             resources to use for job
+        header: list(str), optional
+            list of lines to append to system header for this job
         commands: list(str)
             commands to run in job script after per-machine commands
         exact_fit: bool, default True
@@ -143,7 +145,7 @@ class System:
             sys.stderr.write(f'system {self.id} submit start scheduler submit {time.time()}\n')
         try:
             r = self.scheduler.submit(id, str(job_remote_rundir), partition,
-                                      commands, resources.max_time, self.queuing_sys_header,
+                                      commands, resources.max_time, self.queuing_sys_header + header,
                                       node_dict, no_default_header=self.no_default_header, verbose=verbose)
         except Exception:
             if not self.host is None:

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -79,7 +79,7 @@ class System:
         return f'{self.remote_rundir}/{stage_dir.name}'
 
 
-    def submit(self, id, stage_dir, resources, header, commands, exact_fit=True, partial_node=False, verbose=False):
+    def submit(self, id, stage_dir, resources, commands, header_extra=[], exact_fit=True, partial_node=False, verbose=False):
         """Submit a job on a remote machine, including staging out files
 
         Parameters
@@ -90,10 +90,10 @@ class System:
             directory in which files have been prepared
         resources: Resources
             resources to use for job
-        header: list(str), optional
-            list of lines to append to system header for this job
         commands: list(str)
             commands to run in job script after per-machine commands
+        header_extra: list(str), optional
+            list of lines to append to system header for this job
         exact_fit: bool, default True
             only match partitions that have nodes with exact match to number of tasks
         partial_node: bool, default False
@@ -145,7 +145,7 @@ class System:
             sys.stderr.write(f'system {self.id} submit start scheduler submit {time.time()}\n')
         try:
             r = self.scheduler.submit(id, str(job_remote_rundir), partition,
-                                      commands, resources.max_time, self.queuing_sys_header + header,
+                                      commands, resources.max_time, self.queuing_sys_header + header_extra,
                                       node_dict, no_default_header=self.no_default_header, verbose=verbose)
         except Exception:
             if not self.host is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def expyre_dummy_config(tmp_path):
 @pytest.fixture()
 def expyre_config(tmp_path):
     if not str(tmp_path).startswith(str(Path.home())):
-        pytest.xfail(reason='expyre tests require tmp_path be under $HOME, pass "--basetemp $HOME/pytest"')
+        pytest.fail(reason='expyre tests require tmp_path be under $HOME, pass "--basetemp $HOME/pytest"')
 
     # make a root directory, copy in config.json
     expyre_root = Path(tmp_path / '.expyre')
@@ -71,7 +71,7 @@ def expyre_config(tmp_path):
             system.remote_rundir = str(tmp_path / f'pytest_expyre_rundir_{sys_name}' / orig_remote_rundir[sys_name])
         else:
             # NOTE: should make this something unique for each run
-            system.remote_rundir = f'pytest_expyre_rundir_{sys_name}/' + str(Path(tmp_path).name) + '/' + orig_remote_rundir[sys_name]
+            system.remote_rundir = str(Path(f'pytest_expyre_rundir_{sys_name}') / tmp_path.name / orig_remote_rundir[sys_name])
 
         system.run(['mkdir', '-p', system.remote_rundir])
 


### PR DESCRIPTION
Enable per-job header lines that are passed to `ExPyRe.start(..., header_extra=['#$ header1', '#$ header2'], ...)`

Is there a need for other sources, e.g. per partition in `.expyre/config.json` ?

Note that `wfl` will need a corresponding patch to pass this info.