### PR TITLE
Improve handling of failures of remote jobs

### DIFF
--- a/expyre/__init__.py
+++ b/expyre/__init__.py
@@ -1,2 +1,2 @@
 from .config import systems
-from .func import ExPyRe
+from .func import ExPyRe, ExPyReJobDied

--- a/expyre/jobsdb.py
+++ b/expyre/jobsdb.py
@@ -27,14 +27,14 @@ class JobsDB:
             started - job has started running
             succeeded - job has finished successfully, and results are available
             failed - job has failed
+            died - job died without producing expected low level output
             processed - job has been processed, and results no longer need to be saved
             cleaned - job stage dir (local and remote) has been cleaned (large files overwritten or all files wiped)
     """
 
-    possible_status = ['created', 'submitted', 'started', 'succeeded', 'failed', 'processed', 'cleaned']
+    possible_status = ['created', 'submitted', 'started', 'succeeded', 'failed', 'died', 'processed', 'cleaned']
     status_group = {'ongoing': ['created', 'submitted', 'started'],
-                    'unprocessed': ['succeeded', 'failed'],
-                    'can_produce_results': ['created', 'submitted', 'started', 'succeeded']}
+                    'can_produce_results': ['created', 'submitted', 'started', 'succeeded', 'died']}
 
 
     def _execute(self, cmd, retry_n=3, retry_wait=1):

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -179,7 +179,7 @@ def do_work(sys_name):
     # wipe existing job objects
     xpr = None
     # recreate from JobsDB
-    xpr = ExPyRe.from_jobsdb(db.jobs(status=['ongoing', 'unprocessed']))
+    xpr = ExPyRe.from_jobsdb(db.jobs(status=['ongoing']))
     assert len(xpr) == 1
     xpr = xpr[0]
 

--- a/tests/test_remote_exception.py
+++ b/tests/test_remote_exception.py
@@ -1,0 +1,26 @@
+import sys
+import math
+
+import pytest
+
+from expyre.resources import Resources
+
+def do_remote_exception(sys_name):
+    from expyre import ExPyRe
+
+    xpr = ExPyRe('test_exception', function=math.log, args=[-1.0])
+    xpr.start(resources=Resources(n=(1, 'nodes'), max_time='1m'), system_name=sys_name)
+
+    with pytest.raises(ValueError):
+        results = xpr.get_results(check_interval=5)
+
+def test_remote_exception(expyre_config):
+    from expyre import config
+
+    for sys_name in config.systems:
+        if sys_name.startswith('_'):
+            continue
+
+        sys.stderr.write(f'Test remote exception job {sys_name}\n');
+
+        do_remote_exception(sys_name)


### PR DESCRIPTION
If remote job raises exception, make local process raise the same exception, rather than generic `RuntimeError`.

Distinguish jobs that died (usually timed out, or maybe exceeded memory limit) from those that failed with a remote exception, so they can (in principle) be handled differently.