### PR TITLE
Allow per-partition override of partition name and additional header fields

### DIFF
--- a/expyre/func.py
+++ b/expyre/func.py
@@ -374,7 +374,10 @@ class ExPyRe:
         if self.remote_id is None:
             return
         if self.status in JobsDB.status_group['ongoing']:
-            config.systems[self.system_name].scheduler.cancel(self.remote_id, verbose=verbose)
+            try:
+                config.systems[self.system_name].scheduler.cancel(self.remote_id, verbose=verbose)
+            except Exception:
+                pass
 
 
     def start(self, resources, system_name=os.environ.get('EXPYRE_SYS', None), header_extra=[],

--- a/expyre/subprocess.py
+++ b/expyre/subprocess.py
@@ -153,11 +153,11 @@ def subprocess_run(host, args, script=None, shell='bash -lc', remsh_cmd=None, re
         except Exception:
             if i_try == retry[0]-1:
                 # last try
-                _my_warn(f'Failed to run "{" ".join(args)}" on attempt {i_try} for the last time, giving up')
+                _my_warn(f'Failed to run "{" ".join(args)}" on attempt {i_try} for the last time, giving up.\nSTDERR\n{stderr.decode()}')
 
                 # failed last chance
                 raise
-            _my_warn(f'Failed to run "{" ".join(args)}" on attempt {i_try}, trying again')
+            _my_warn(f'Failed to run "{" ".join(args)}" on attempt {i_try}, trying again.\nSTDERR\n{stderr.decode()}')
 
         time.sleep(retry[1])
 

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -109,6 +109,13 @@ class System:
 
         partition, node_dict = resources.find_nodes(self.partitions, exact_fit=exact_fit,
                                                     partial_node=partial_node)
+        # add partition-specific header after per-system header but before header specific
+        # to this submission
+        header_extra = self.partitions[partition].get("header", []) + header_extra
+        # override default partition name from dict key (but after using dict key to look up
+        # other things like header above)
+        actual_partition = self.partitions[partition].get("partition", partition)
+
         commands = self.commands + commands
 
         stage_dir = Path(stage_dir)
@@ -144,7 +151,7 @@ class System:
         if 'EXPYRE_TIMING_VERBOSE' in os.environ:
             sys.stderr.write(f'system {self.id} submit start scheduler submit {time.time()}\n')
         try:
-            r = self.scheduler.submit(id, str(job_remote_rundir), partition,
+            r = self.scheduler.submit(id, str(job_remote_rundir), actual_partition,
                                       commands, resources.max_time, self.queuing_sys_header + header_extra,
                                       node_dict, no_default_header=self.no_default_header, verbose=verbose)
         except Exception:


### PR DESCRIPTION
Massaging of various dict fields in `system.py` to allow override of partition name and per-partition additional header fields.