### PR TITLE
use EXPYRE_HEADER_EXTRA

### DIFF
--- a/expyre/schedulers/pbs.py
+++ b/expyre/schedulers/pbs.py
@@ -1,3 +1,5 @@
+import os
+import json
 import re
 
 from ..subprocess import subprocess_run
@@ -89,6 +91,8 @@ class PBS(Scheduler):
             header.append('#PBS -e job.{id}.stderr')
             header.append('#PBS -S /bin/bash')
             header.append('#PBS -r n')
+
+        header.extend(json.loads(os.environ.get("EXPYRE_HEADER_EXTRA", "[]")))
 
         # set EXPYRE_NUM_CORES_PER_NODE using scheduler-specific info, to support jobs
         # that do not know exact node type at submit time.  All related quantities

--- a/expyre/schedulers/sge.py
+++ b/expyre/schedulers/sge.py
@@ -1,3 +1,5 @@
+import os
+import json
 import re
 
 from ..subprocess import subprocess_run
@@ -70,6 +72,8 @@ class SGE(Scheduler):
             header.append('#$ -S /bin/bash')
             header.append('#$ -r n')
             header.append('#$ -cwd')
+
+        header.extend(json.loads(os.environ.get("EXPYRE_HEADER_EXTRA", "[]")))
 
         # set EXPYRE_NUM_CORES_PER_NODE using scheduler-specific info, to support jobs
         # that do not know exact node type at submit time.  All related quantities

--- a/expyre/schedulers/slurm.py
+++ b/expyre/schedulers/slurm.py
@@ -1,3 +1,5 @@
+import os
+import json
 import re
 
 from ..subprocess import subprocess_run
@@ -65,6 +67,8 @@ class Slurm(Scheduler):
             header.append('#SBATCH --time={max_time}')
             header.append('#SBATCH --output=job.{id}.stdout')
             header.append('#SBATCH --error=job.{id}.stderr')
+
+        header.extend(json.loads(os.environ.get("EXPYRE_HEADER_EXTRA", "[]")))
 
         # set EXPYRE_NUM_CORES_PER_NODE using scheduler-specific info, to support jobs
         # that do not know exact node type at submit time.  All related quantities


### PR DESCRIPTION
Append lines from env var `EXPYRE_HEADER_EXTRA` to scheduler header, for things like reservations that are only known at runtime so shouldn't be fixed in `~/.expyre/config.json`