### PR TITLE
Enable running jobs in rundir even if host = None

### DIFF
--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # export EXPYRE_PYTEST_SYSTEMS='(tin|mustang)'
-export EXPYRE_PYTEST_SYSTEMS='tin'
+export EXPYRE_PYTEST_SYSTEMS='tin|tin_stage'
 
 echo  "GIT VERSION " $( git describe --always --tags --dirty ) > complete_pytest.tin.out
 echo "" >> complete_pytest.tin.out

--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -28,7 +28,7 @@ if [ $? != 0 ]; then
     echo "Unexpected number skipped not 0 '$l'" 1>&2
     exit 1
 fi
-echo $l | grep -q ' 26 passed'
+echo $l | grep -q ' 29 passed'
 if [ $? != 0 ]; then
     echo "Unexpected number passed not 26 '$l'" 1>&2
     exit 1

--- a/expyre/config.py
+++ b/expyre/config.py
@@ -108,19 +108,18 @@ def init(root_dir, verbose=False):
     global local_stage_dir, systems, db
 
     try:
-        root, _config_data = _get_config(root_dir, verbose=verbose)
+        local_stage_dir, _config_data = _get_config(root_dir, verbose=verbose)
     except FileNotFoundError:
+        local_stage_dir = None
         systems = {}
         db = None
         return
 
-    if root.name == '.expyre' or root.name == '_expyre':
-        use_root = root.parent
+    if local_stage_dir.name == '.expyre' or local_stage_dir.name == '_expyre':
+        use_local_stage_dir = local_stage_dir.parent
     else:
-        use_root = root
-    _rundir_extra = os.environ.get('HOSTNAME', 'unkownhost') + '-' + str(use_root).replace('/', '_')
-
-    local_stage_dir = _config_data.get("local_stage_dir", root)
+        use_local_stage_dir = local_stage_dir
+    _rundir_extra = os.environ.get('HOSTNAME', 'unkownhost') + '-' + str(use_local_stage_dir).replace('/', '_')
 
     systems = {}
     for _sys_name in _config_data['systems']:
@@ -135,7 +134,7 @@ def init(root_dir, verbose=False):
                 _sys_data['partitions'][_partitions]['max_mem'] = mem_to_kB(_sys_data['partitions'][_partitions]['max_mem'])
         systems[_sys_name] = System(rundir_extra=_rundir_extra, **_sys_data)
 
-    db = JobsDB(root / 'jobs.db')
+    db = JobsDB(local_stage_dir / 'jobs.db')
     if verbose:
         sys.stderr.write(f'expyre config got systems {list(systems.keys())}\n')
 

--- a/expyre/config.py
+++ b/expyre/config.py
@@ -68,7 +68,10 @@ def _get_config(root_dir, verbose=False):
         dirs = list(reversed(dirs))
     else:
         if verbose: print("Exact directory", root_dir)
-        dirs = [Path(root_dir)]
+        root_dir = Path(root_dir)
+        if not root_dir.is_dir():
+            raise ValueError(f"expyre root {root_dir} is not a dir")
+        dirs = [root_dir]
 
     if verbose: print("Using directories", dirs)
 

--- a/expyre/config.py
+++ b/expyre/config.py
@@ -87,7 +87,7 @@ def _get_config(root_dir, verbose=False):
         raise FileNotFoundError('Failed to find any config.json file')
 
     # use explicitly specified local_stage_dir, otherwise deepest config dir
-    local_stage_dir = config_data.get("local_stage_dir", dirs[-1])
+    local_stage_dir = Path(config_data.get("local_stage_dir", dirs[-1]))
 
     return local_stage_dir, config_data
 

--- a/expyre/config.py
+++ b/expyre/config.py
@@ -1,8 +1,9 @@
-"""configuration for expyre from ``config.json``. Use env var ``EXPYRE_ROOT`` is set,
-otherwise search from ``HOME`` (or ``/``, if current dir is not below ``HOME``) down to current directory
-for ``.expyre`` or ``_expyre``.  Configuration is parsed in the same order, with deeper directories
-modifying previous ones.  ``local_stage_dir`` is set to deepest directory unless it is set
-explicitly.
+"""configuration for expyre from ``config.json``. Use env var ``EXPYRE_ROOT`` if set.
+Otherwise (or if env var is set to ``@``), search from ``HOME`` (or ``/``, if current
+dir is not below ``HOME``) down to current directory for ``.expyre`` or ``_expyre``.
+Configuration is parsed in the same order, with deeper directories modifying previous
+ones.  ``local_stage_dir`` is set to deepest directory unless it is set explicitly
+in one of the found ``config.json`` files.
 
 Global variables
 ----------------
@@ -44,7 +45,7 @@ def update_dict_leaves(d, d_loc):
 def _get_config(root_dir, verbose=False):
     """get configuration from root dir
     """
-    if root_dir == "@.":
+    if root_dir == "@":
         if verbose: print("Searching directories")
         # search the path
         dirs = []
@@ -137,4 +138,4 @@ def init(root_dir, verbose=False):
 
 
 if 'pytest' not in sys.modules:
-    init(os.environ.get("EXPYRE_ROOT"))
+    init(os.environ.get("EXPYRE_ROOT", "@"))

--- a/expyre/func.py
+++ b/expyre/func.py
@@ -195,7 +195,7 @@ class ExPyRe:
                 return
 
         # didn't find an old run, need to create new and unique stage dir
-        self.stage_dir = Path(tempfile.mkdtemp(prefix=f'run_{name}_{arghash}_', dir=config.root))
+        self.stage_dir = Path(tempfile.mkdtemp(prefix=f'run_{name}_{arghash}_', dir=config.local_stage_dir))
         # id is property derived from stage dir, so it is also unique
 
         if 'EXPYRE_TIMING_VERBOSE' in os.environ:

--- a/expyre/subprocess.py
+++ b/expyre/subprocess.py
@@ -205,8 +205,8 @@ def subprocess_copy(from_files, to_file, from_host='_LOCAL_', to_host='_LOCAL_',
         verbose output
     """
     # exactly one of from_host, to_host must be provided
-    if sum([from_host == '_LOCAL_', to_host == '_LOCAL_']) != 1:
-        raise RuntimeError(f'Exactly one of source host "{from_host}" or target host "{to_host}" must passed in')
+    if from_host != '_LOCAL_' and to_host != '_LOCAL_':
+        raise RuntimeError(f'Cannot have remote machine for both of source host "{from_host}" and "{to_host}"')
 
     if remsh_cmd is None:
         remsh_cmd = os.environ.get('EXPYRE_RSH', 'ssh')

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -30,25 +30,31 @@ class System:
         max runtime, and stdout/stderr files
     commands: list(str), optional
         list of commands to run at start of every job on machine
-    rundir: str, default 'run_expyre'
-        path on remote machine to run in.  If absolute, used as if, and if relative, relative
-        to (remote) home directory
+    rundir: str / None, default 'run_expyre' if host is not None, else None
+        path on remote machine to run in.  If absolute, used as is, and if relative, relative
+        to (remote) home directory. If host is None, rundir is None means run directly
+        in stage directory
     remsh_cmd: str, default EXPYRE_RSH or 'ssh'
         remote shell command to use with this system
     rundir_extra: str, default None
         extra string to add to remote_rundir, e.g. per-project part of path
     """
     def __init__(self, host, partitions, scheduler, header=[], no_default_header=False, commands=[],
-                 rundir='run_expyre', rundir_extra=None, remsh_cmd=None):
-        """Create a remote system object
-
-
-        """
+                 rundir=None, rundir_extra=None, remsh_cmd=None):
         self.host = host
+
         self.remote_rundir = rundir
-        while self.remote_rundir.endswith('/'):
-            self.remote_rundir = self.remote_rundir[:-1]
-        if rundir_extra is not None:
+        if self.remote_rundir is None and self.host is not None:
+            # set default for remote runs
+            self.remote_rundir = 'run_expyre'
+        if self.host is None and self.remote_rundir is not None and not Path(self.remote_rundir).is_absolute():
+            # make local runs be relative to $HOME
+            self.remote_rundir = str(Path.home() / self.remote_rundir)
+
+        if self.remote_rundir is not None:
+            while self.remote_rundir.endswith('/'):
+                self.remote_rundir = self.remote_rundir[:-1]
+        if rundir_extra is not None and self.remote_rundir is not None:
             self.remote_rundir += '/' + rundir_extra
         self.partitions = partitions.copy() if partitions is not None else partitions
         self.queuing_sys_header = header.copy()
@@ -70,7 +76,7 @@ class System:
 
 
     def initialize_remote_rundir(self, verbose=False):
-        if self.initialized or self.host is None:
+        if self.initialized or self.remote_rundir is None:
             return
 
         self.run(['mkdir', '-p', str(self.remote_rundir)], verbose=verbose)
@@ -121,7 +127,7 @@ class System:
         commands = self.commands + commands
 
         stage_dir = Path(stage_dir)
-        if self.host is None:
+        if self.remote_rundir is None:
             # no host, so run in stage dir to avoid needless copying
             job_remote_rundir = str(stage_dir)
         else:
@@ -157,8 +163,9 @@ class System:
                                       commands, resources.max_time, self.queuing_sys_header + header_extra,
                                       node_dict, no_default_header=self.no_default_header, verbose=verbose)
         except Exception:
-            if not self.host is None:
-                sys.stderr.write(f'System.submit call to Scheduler.submit failed for job id {id}, cleaning up remote dir {str(self.remote_rundir)}\n')
+            if self.remote_rundir is not None:
+                sys.stderr.write(f'System.submit call to Scheduler.submit failed for job id {id}, '
+                                 f'cleaning up remote dir {str(self.remote_rundir)}\n')
                 self.run(['rm', '-r', str(job_remote_rundir)], verbose=verbose)
             raise
 
@@ -175,7 +182,7 @@ class System:
         subdir_glob: str, list(str), default None
             only get subdirectories that much one or more globs
         """
-        if self.host is None:
+        if self.remote_rundir is None:
             # nothing to "get" since this ran in stage dir
             return
 
@@ -205,7 +212,7 @@ class System:
         verbose: bool, default False
             verbose output
         """
-        if self.host is None:
+        if self.remote_rundir is None:
             # the job remote rundir _is_ the stage dir, so do not delete here
             return
 

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -48,7 +48,8 @@ class System:
             # set default for remote runs
             self.remote_rundir = 'run_expyre'
         if self.host is None and self.remote_rundir is not None and not Path(self.remote_rundir).is_absolute():
-            # make local runs be relative to $HOME
+            # make local runs with non-absolute rundir relative to $HOME, mimicking behavior
+            # of rsync with remote directory specifications
             self.remote_rundir = str(Path.home() / self.remote_rundir)
 
         if self.remote_rundir is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,12 +68,14 @@ def expyre_config(tmp_path):
             orig_remote_rundir[sys_name] = system.remote_rundir
 
         if system.host is None:
-            system.remote_rundir = str(tmp_path / f'pytest_expyre_rundir_{sys_name}' / orig_remote_rundir[sys_name])
+            if system.remote_rundir is not None:
+                system.remote_rundir = str(tmp_path / f'pytest_expyre_rundir_{sys_name}' / orig_remote_rundir[sys_name])
         else:
             # NOTE: should make this something unique for each run
             system.remote_rundir = str(Path(f'pytest_expyre_rundir_{sys_name}') / tmp_path.name / orig_remote_rundir[sys_name])
 
-        system.run(['mkdir', '-p', system.remote_rundir])
+        if system.remote_rundir is not None:
+            system.run(['mkdir', '-p', system.remote_rundir])
 
 
 # from https://stackoverflow.com/questions/62044541/change-pytest-working-directory-to-test-case-directory

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,93 @@
+import pytest
+
+from pathlib import Path
+from copy import deepcopy
+import json
+
+
+def test_update_dict_leaves(expyre_dummy_config):
+    from expyre.config import update_dict_leaves
+
+    d = {1: 2, 3: 4, 5: ["a", "b"], "d": {1: 2, 3: 4}}
+    d_ref = deepcopy(d)
+    print("d", d)
+    assert d == d_ref
+
+    update_dict_leaves(d, {3: "new"})
+    d_ref[3] = "new"
+    print("updated d", d)
+    assert d == d_ref
+
+    update_dict_leaves(d, {"d": {1: "new"}})
+    d_ref["d"][1] = "new"
+    print("updated d", d)
+    assert d == d_ref
+
+    update_dict_leaves(d, {5: "_DELETE_"})
+    del d_ref[5]
+    print("updated d", d)
+    assert d == d_ref
+
+    with pytest.raises(AssertionError):
+        update_dict_leaves(d, {3: {1: 2}})
+
+
+def test_config_nested(expyre_dummy_config, monkeypatch, tmp_path):
+    from expyre import config
+    sys_name = list(config.systems)[0]
+    print(config.systems[sys_name].partitions)
+
+    # start at tmp_path
+    monkeypatch.chdir(tmp_path)
+
+    # make a subdirectory with .expyre inside it
+    (Path() / "sub1" / ".expyre").mkdir(parents=True)
+    monkeypatch.chdir("sub1")
+    print("CWD", Path.cwd())
+    config.init("@.", verbose=True)
+    print("config.local_stage_dir", config.local_stage_dir)
+    # make sure stage dir is in cwd
+    assert Path(config.local_stage_dir) == Path.cwd() / ".expyre"
+
+    # make a subdirectory with _expyre inside it
+    (Path() / "sub2" / "_expyre").mkdir(parents=True)
+    monkeypatch.chdir("sub2")
+    print("CWD", Path.cwd())
+    config.init("@.", verbose=True)
+    print("config.local_stage_dir", config.local_stage_dir)
+    # make sure stage dir is in cwd
+    assert Path(config.local_stage_dir) == Path.cwd() / "_expyre"
+
+    # make a subdirectory without _expyre inside it
+    (Path() / "sub3").mkdir(parents=True)
+    monkeypatch.chdir("sub3")
+    print("CWD", Path.cwd())
+    config.init("@.", verbose=True)
+    print("config.local_stage_dir", config.local_stage_dir)
+    # make sure stage dir is _one above_ cwd
+    assert Path(config.local_stage_dir) == Path.cwd().parent / "_expyre"
+
+
+def test_config_override(expyre_dummy_config, monkeypatch, tmp_path):
+    from expyre import config
+    sys_name = list(config.systems)[0]
+    print(config.systems[sys_name].partitions)
+    assert config.systems[sys_name].partitions["node32"]["max_time"] == None
+
+    orig_partitions = deepcopy(config.systems[sys_name].partitions)
+
+    # start at tmp_path
+    monkeypatch.chdir(tmp_path)
+
+    # make a subdirectory with .expyre inside it
+    (Path() / "sub1" / ".expyre").mkdir(parents=True)
+    monkeypatch.chdir("sub1")
+
+    with open(".expyre/config.json", "w") as fout:
+        fout.write(json.dumps({"systems": {sys_name: {"partitions": {"node32": {"max_time": 1}}}}}))
+    print("CWD", Path.cwd())
+    config.init("@.", verbose=True)
+    print(config.systems[sys_name].partitions)
+    
+    orig_partitions["node32"]["max_time"] = 1
+    assert orig_partitions == config.systems[sys_name].partitions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,7 +44,7 @@ def test_config_nested(expyre_dummy_config, monkeypatch, tmp_path):
     (Path() / "sub1" / ".expyre").mkdir(parents=True)
     monkeypatch.chdir("sub1")
     print("CWD", Path.cwd())
-    config.init("@.", verbose=True)
+    config.init("@", verbose=True)
     print("config.local_stage_dir", config.local_stage_dir)
     # make sure stage dir is in cwd
     assert Path(config.local_stage_dir) == Path.cwd() / ".expyre"
@@ -53,7 +53,7 @@ def test_config_nested(expyre_dummy_config, monkeypatch, tmp_path):
     (Path() / "sub2" / "_expyre").mkdir(parents=True)
     monkeypatch.chdir("sub2")
     print("CWD", Path.cwd())
-    config.init("@.", verbose=True)
+    config.init("@", verbose=True)
     print("config.local_stage_dir", config.local_stage_dir)
     # make sure stage dir is in cwd
     assert Path(config.local_stage_dir) == Path.cwd() / "_expyre"
@@ -62,7 +62,7 @@ def test_config_nested(expyre_dummy_config, monkeypatch, tmp_path):
     (Path() / "sub3").mkdir(parents=True)
     monkeypatch.chdir("sub3")
     print("CWD", Path.cwd())
-    config.init("@.", verbose=True)
+    config.init("@", verbose=True)
     print("config.local_stage_dir", config.local_stage_dir)
     # make sure stage dir is _one above_ cwd
     assert Path(config.local_stage_dir) == Path.cwd().parent / "_expyre"
@@ -86,7 +86,7 @@ def test_config_override(expyre_dummy_config, monkeypatch, tmp_path):
     with open(".expyre/config.json", "w") as fout:
         fout.write(json.dumps({"systems": {sys_name: {"partitions": {"node32": {"max_time": 1}}}}}))
     print("CWD", Path.cwd())
-    config.init("@.", verbose=True)
+    config.init("@", verbose=True)
     print(config.systems[sys_name].partitions)
     
     orig_partitions["node32"]["max_time"] = 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 from copy import deepcopy
 import json
+import shutil
 
 
 def test_update_dict_leaves(expyre_dummy_config):
@@ -66,6 +67,25 @@ def test_config_nested(expyre_dummy_config, monkeypatch, tmp_path):
     print("config.local_stage_dir", config.local_stage_dir)
     # make sure stage dir is _one above_ cwd
     assert Path(config.local_stage_dir) == Path.cwd().parent / "_expyre"
+
+
+def test_config_specific_dir_as_str(expyre_dummy_config, monkeypatch, tmp_path):
+    from expyre import config
+    sys_name = list(config.systems)[0]
+    print(config.systems[sys_name].partitions)
+
+    # start at tmp_path
+    monkeypatch.chdir(tmp_path)
+
+    # make a subdirectory with .expyre inside it
+    (Path() / "sub1" / ".expyre").mkdir(parents=True)
+    monkeypatch.chdir("sub1")
+    print("CWD", Path.cwd())
+    shutil.copy(config.local_stage_dir / "config.json", Path.cwd() / ".expyre")
+    config.init(str(Path.cwd() / ".expyre"), verbose=True)
+    print("config.local_stage_dir", config.local_stage_dir)
+    # make sure stage dir is in cwd
+    assert Path(config.local_stage_dir) == Path.cwd() / ".expyre"
 
 
 def test_config_override(expyre_dummy_config, monkeypatch, tmp_path):

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -16,6 +16,9 @@ def test_qsub_failure_atomic(expyre_config, monkeypatch):
 def do_qsub_failure_atomic(expyre_config, sys_name, monkeypatch):
     # make sure that a failed qsub cleans up the remote running directory
 
+    # WARNING: this test will only work if it is being run on same machine as job
+    # was executed on (i.e. not really remote) because it is manually looking in remote_rundir
+
     from expyre.config import systems
     from expyre.resources import Resources
     from expyre.func import ExPyRe
@@ -37,10 +40,11 @@ def do_qsub_failure_atomic(expyre_config, sys_name, monkeypatch):
     except RuntimeError:
         print('ExPyRe.start failed, checking state of remote dir')
 
-    # make sure remote rundir exists
-    stdout, stderr = system.run(['ls', '-d', f'{system.remote_rundir}'])
-    assert system.remote_rundir in stdout
+    if system.remote_rundir is not None:
+        # make sure remote rundir exists
+        stdout, stderr = system.run(['ls', '-d', f'{system.remote_rundir}'])
+        assert system.remote_rundir in stdout
 
-    # make sure job remote rundir does not exist
-    stdout, stderr = system.run(['ls', f'{system.remote_rundir}'])
-    assert xpr.id not in stdout
+        # make sure job remote rundir does not exist
+        stdout, stderr = system.run(['ls', f'{system.remote_rundir}'])
+        assert xpr.id not in stdout

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -190,6 +190,9 @@ def do_work(sys_name):
 
 
 def do_clean(sys_name, dry_run):
+    # WARNING: this test will only work if it is being run on same machine as job
+    # was executed on (i.e. not really remote) because it is manually looking in remote_rundir
+
     from expyre.config import systems
     from expyre.func import ExPyRe
 
@@ -211,8 +214,8 @@ def do_clean(sys_name, dry_run):
         for f in xpr.stage_dir.glob('*'):
             p = subprocess.run(['wc', '-c', f'{f}'], capture_output=True)
             local_post_clean += p.stdout.decode()
-        if system.host is not None:
-            # If system.host is None run will happen in local stage dir, so there's no remote
+        if system.remote_rundir is not None:
+            # If system.remote_rundir is None run will happen in local stage dir, so there's no remote
             # dir to check
             stdout, _ = system.run(args=['bash'], script=f'cd {system.remote_rundir}/{xpr.stage_dir.name} && wc -c *\n')
             remote_post_clean = stdout
@@ -231,7 +234,7 @@ def do_clean(sys_name, dry_run):
 
     # check that stage directories are gone
     assert dry_run or not xpr.stage_dir.exists()
-    if not dry_run:
+    if not dry_run and system.remote_rundir is not None:
         stdout, _ = system.run(args=['bash'],
                                script=f'if [ -f {system.remote_rundir}/{xpr.stage_dir.name} ]; then\n'
                                        '    echo yes\n'

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -134,7 +134,7 @@ def test_stdouterr(expyre_config):
 
 
 def do_stdouterr(sys_name):
-    from expyre.config import root, db
+    from expyre.config import db
 
     from expyre.func import ExPyRe
 
@@ -160,7 +160,8 @@ def do_stdouterr(sys_name):
 
 
 def do_work(sys_name):
-    from expyre.config import root, db
+    from expyre.config import local_stage_dir, db
+    local_stage_dir = Path(local_stage_dir)
 
     # must do this here rather than outside of functions because expyre.func imports config, and it's not
     # yet set up by conftest.py if imported outside the test function
@@ -170,9 +171,9 @@ def do_work(sys_name):
 
     print('job id', xpr.id)
 
-    assert (Path(root) / f'run_{xpr.id}').exists()
-    assert (Path(root) / f'run_{xpr.id}' / '_expyre_script_core.py').exists()
-    assert (Path(root) / f'run_{xpr.id}' / '_expyre_task_in.pckl').exists()
+    assert (local_stage_dir / f'run_{xpr.id}').exists()
+    assert (local_stage_dir / f'run_{xpr.id}' / '_expyre_script_core.py').exists()
+    assert (local_stage_dir / f'run_{xpr.id}' / '_expyre_task_in.pckl').exists()
 
     xpr.start(resources=Resources(num_nodes=1, max_time='5m'), system_name=sys_name)
 


### PR DESCRIPTION
Fix bug where having `host = None` caused `rundir` to be ignored, and all jobs run directly from stage dir.  Now `rundir = None` (and `host = None`) will cause this behavior, but specifying a value should stage to `rundir` (e.g. a scratch directory).  This will still result in two extra copies, just like a real remote job - one from original to stage, one from stage to rundir (except that this is local, not remote).

Add `local_stage_dir` key to top level of `config.json`. Makes it possible to set the stage dir to scratch, which (with host None and no rundir) makes it stage to scratch and then run directly there.

Redo the way the root directory and config.json are searched and used to determine the final config info, so subdirectories can override the `local_stage_dir` key.

closes #31 