### PR TITLE
Don't pass '-l' to bash

### DIFF
--- a/expyre/subprocess.py
+++ b/expyre/subprocess.py
@@ -81,7 +81,7 @@ def _optionally_remote_args(args, shell, host, remsh_cmd, in_dir='_HOME_'):
     return args
 
 
-def subprocess_run(host, args, script=None, shell='bash -lc', remsh_cmd=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
+def subprocess_run(host, args, script=None, shell='bash -c', remsh_cmd=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
     """run a subprocess, optionally via ssh on a remote machine.  Raises RuntimeError for non-zero
     return status.
 
@@ -93,7 +93,7 @@ def subprocess_run(host, args, script=None, shell='bash -lc', remsh_cmd=None, re
         arguments to run, starting with command and followed by its command line args
     script: str, default None
         text to write to process's standard input
-    shell: str, default 'bash -lc'
+    shell: str, default 'bash -c'
         shell to use, including any flags necessary for it to interpret the next argument
         as the commands to run (-c for bash)
     remsh_command: str | list(str), default env var EXPYRE_RSH or 'ssh'

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -70,7 +70,7 @@ class System:
             self.scheduler = scheduler(host)
 
 
-    def run(self, args, script=None, shell='bash -lc', retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
+    def run(self, args, script=None, shell='bash -c', retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
         # like subprocess_run, but filling in host and remsh command from self
         return subprocess_run(self.host, args, script=script, shell=shell, remsh_cmd=self.remsh_cmd,
                               retry=retry, in_dir=in_dir, dry_run=dry_run, verbose=verbose)


### PR DESCRIPTION
No 'bash -l' since that fails to inherit env vars from parent, breaking things like kerberos