### PR TITLE
changing handling of shells

### DIFF
--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # export EXPYRE_PYTEST_SYSTEMS='(tin|mustang)'
-export EXPYRE_PYTEST_SYSTEMS='tin|tin_stage'
+export EXPYRE_PYTEST_SYSTEMS='tin|tin_ssh'
 
 echo  "GIT VERSION " $( git describe --always --tags --dirty ) > complete_pytest.tin.out
 echo "" >> complete_pytest.tin.out

--- a/expyre/schedulers/base.py
+++ b/expyre/schedulers/base.py
@@ -20,7 +20,8 @@ class Scheduler:
         self.remsh_cmd = util.remsh_cmd(remsh_cmd)
 
 
-    def submit(self, id, remote_dir, partition, commands, max_time, header, node_dict, no_default_header=False, verbose=False):
+    def submit(self, id, remote_dir, partition, commands, max_time, header, node_dict, no_default_header=False,
+               script_exec="/bin/bash", pre_submit_cmds=[], verbose=False):
         raise RuntimeError('Not implemented')
 
 

--- a/expyre/schedulers/slurm.py
+++ b/expyre/schedulers/slurm.py
@@ -20,7 +20,6 @@ class Slurm(Scheduler):
         remote shell command to use
     """
     def __init__(self, host, remsh_cmd=None):
-
         self.host = host
         self.hold_command = ['scontrol', 'hold']
         self.release_command = ['scontrol', 'release']
@@ -28,7 +27,8 @@ class Slurm(Scheduler):
         self.remsh_cmd = util.remsh_cmd(remsh_cmd)
 
 
-    def submit(self, id, remote_dir, partition, commands, max_time, header, node_dict, no_default_header=False, verbose=False):
+    def submit(self, id, remote_dir, partition, commands, max_time, header, node_dict, no_default_header=False,
+               script_exec="/bin/bash", pre_submit_cmds=[], verbose=False):
         """Submit a job on a remote machine
 
         Parameters
@@ -50,6 +50,11 @@ class Slurm(Scheduler):
             Fields: num_nodes, num_cores, num_cores_per_node, ppn, id, max_time, partition (and its synonum queue)
         no_default_header: bool, default False
             do not add normal header fields, only use what's passed in in "header"
+        script_exec: str, default '/bin/bash'
+            executable for first line of job script
+        pre_submit_cmds: list(str), default []
+            command to run in the remote process that does the submission before the actual submission,
+            e.g. to fix the environment
 
         Returns
         -------
@@ -92,13 +97,14 @@ class Slurm(Scheduler):
 
         commands = pre_commands + commands
 
-        script = '#!/bin/bash -l\n'
+        script = '#!' + script_exec + '\n'
         script += '\n'.join([line.rstrip().format(**node_dict) for line in header]) + '\n'
         script += '\n' + '\n'.join([line.rstrip() for line in commands]) + '\n'
 
         submit_args = Scheduler.unset_scheduler_env_vars("SLURM")
+        submit_args += pre_submit_cmds + (['&&'] if len(pre_submit_cmds) > 0 else [])
         submit_args += ['cd', remote_dir, '&&', 'cat', '>', 'job.script.slurm',
-                       '&&', 'sbatch', 'job.script.slurm']
+                        '&&', 'sbatch', 'job.script.slurm']
 
         stdout, stderr = subprocess_run(self.host, args=submit_args, script=script, remsh_cmd=self.remsh_cmd, verbose=verbose)
 

--- a/expyre/subprocess.py
+++ b/expyre/subprocess.py
@@ -81,7 +81,7 @@ def _optionally_remote_args(args, shell, host, remsh_cmd, in_dir='_HOME_'):
     return args
 
 
-def subprocess_run(host, args, script=None, shell='bash -c', remsh_cmd=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
+def subprocess_run(host, args, script=None, shell=None, remsh_cmd=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
     """run a subprocess, optionally via ssh on a remote machine.  Raises RuntimeError for non-zero
     return status.
 
@@ -93,7 +93,7 @@ def subprocess_run(host, args, script=None, shell='bash -c', remsh_cmd=None, ret
         arguments to run, starting with command and followed by its command line args
     script: str, default None
         text to write to process's standard input
-    shell: str, default 'bash -c'
+    shell: str, default 'bash -c' (no host) or 'bash -lc' (with host)
         shell to use, including any flags necessary for it to interpret the next argument
         as the commands to run (-c for bash)
     remsh_command: str | list(str), default env var EXPYRE_RSH or 'ssh'
@@ -116,6 +116,15 @@ def subprocess_run(host, args, script=None, shell='bash -c', remsh_cmd=None, ret
             retry = tuple([int(_ii) for _ii in os.environ['EXPYRE_RETRY'].strip().split()])
         else:
             retry = (3, 5)
+
+    if shell is None:
+        if host is None:
+            # for local shells, '-l' inhibits inheriting of env vars and breaks things like kerberos auth
+            shell = 'bash -c'
+        else:
+            # for remote machines, login shell is better since it's more likely to set up all the relevant
+            # things
+            shell = 'bash -lc'
 
     # always run at least once, and wait a valid (>= 0) amount of time
     retry = (max(retry[0], 1), max(retry[1], 0))

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -70,7 +70,7 @@ class System:
             self.scheduler = scheduler(host)
 
 
-    def run(self, args, script=None, shell='bash -c', retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
+    def run(self, args, script=None, shell=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
         # like subprocess_run, but filling in host and remsh command from self
         return subprocess_run(self.host, args, script=script, shell=shell, remsh_cmd=self.remsh_cmd,
                               retry=retry, in_dir=in_dir, dry_run=dry_run, verbose=verbose)

--- a/expyre/system.py
+++ b/expyre/system.py
@@ -28,19 +28,23 @@ class System:
     no_default_header: bool, default False
         do not automatically add default header fields, namely job name, partition/queue,
         max runtime, and stdout/stderr files
+    script_exec: str, default '/bin/bash'
+        executable for 1st line of script
+    pre_submit_cmds: list(str), optional
+        command to run in process that does submission before actual job submission
     commands: list(str), optional
         list of commands to run at start of every job on machine
     rundir: str / None, default 'run_expyre' if host is not None, else None
         path on remote machine to run in.  If absolute, used as is, and if relative, relative
         to (remote) home directory. If host is None, rundir is None means run directly
         in stage directory
-    remsh_cmd: str, default EXPYRE_RSH or 'ssh'
-        remote shell command to use with this system
     rundir_extra: str, default None
         extra string to add to remote_rundir, e.g. per-project part of path
+    remsh_cmd: str, default EXPYRE_RSH or 'ssh'
+        remote shell command to use with this system
     """
-    def __init__(self, host, partitions, scheduler, header=[], no_default_header=False, commands=[],
-                 rundir=None, rundir_extra=None, remsh_cmd=None):
+    def __init__(self, host, partitions, scheduler, header=[], no_default_header=False, script_exec='/bin/bash',
+                 pre_submit_cmds=[], commands=[], rundir=None, rundir_extra=None, remsh_cmd=None):
         self.host = host
 
         self.remote_rundir = rundir
@@ -60,6 +64,8 @@ class System:
         self.partitions = partitions.copy() if partitions is not None else partitions
         self.queuing_sys_header = header.copy()
         self.no_default_header = no_default_header
+        self.script_exec = script_exec
+        self.pre_submit_cmds = pre_submit_cmds
         self.commands = commands.copy()
         self.remsh_cmd = util.remsh_cmd(remsh_cmd)
         self.initialized = False
@@ -70,7 +76,7 @@ class System:
             self.scheduler = scheduler(host)
 
 
-    def run(self, args, script=None, shell=None, retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
+    def run(self, args, script=None, shell='bash -c', retry=None, in_dir='_HOME_', dry_run=False, verbose=False):
         # like subprocess_run, but filling in host and remsh command from self
         return subprocess_run(self.host, args, script=script, shell=shell, remsh_cmd=self.remsh_cmd,
                               retry=retry, in_dir=in_dir, dry_run=dry_run, verbose=verbose)
@@ -162,7 +168,8 @@ class System:
         try:
             r = self.scheduler.submit(id, str(job_remote_rundir), actual_partition,
                                       commands, resources.max_time, self.queuing_sys_header + header_extra,
-                                      node_dict, no_default_header=self.no_default_header, verbose=verbose)
+                                      node_dict, no_default_header=self.no_default_header, script_exec=self.script_exec,
+                                      pre_submit_cmds=self.pre_submit_cmds, verbose=verbose)
         except Exception:
             if self.remote_rundir is not None:
                 sys.stderr.write(f'System.submit call to Scheduler.submit failed for job id {id}, '


### PR DESCRIPTION
Get rid of "bash -l" by default everywhere, since it seems to be more problematic than helpful.

Allow config file to control executable in first line of shell script (now just `/usr/bin/bash` by default), so they can add `-l` flag if that works.

Allow config file to add commands that are run in the (remote) process that _submits_ the queued job, to, for example, fix the environment (since ssh to remote machine will do things like wipe PYTHONPATH, but some machines make it difficult to restore it once you're already in the running job, by making it hard to re-initialize environment modules in that state - they want to inherit it from the submitting process.)