### PR TITLE
more versatile handling of selected partition/queue to queuing system header line

### DIFF
--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -30,7 +30,7 @@ if [ $? != 0 ]; then
 fi
 echo $l | grep -q ' 29 passed'
 if [ $? != 0 ]; then
-    echo "Unexpected number passed not 26 '$l'" 1>&2
+    echo "Unexpected number passed not 30 '$l'" 1>&2
     exit 1
 fi
 echo $l | grep -q -v 'xfailed'

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -13,16 +13,16 @@ File format
 
 The top level structure is a single dict with one ``"systems"`` key with a dict value, containing
 one key-value pair for each system. The key is the name of the system (used to select
-the system when evaluating the function).  See ``expyre.System`` docstring for full list. The value is a dict with the following keys:
+the system when evaluating the function).  See ``expyre.System`` docstring for full list. The
+value is a dict with the following keys:
 
 - ``"host"``: string hostname, with optional ``username@`, or ``null`` for localhost without ssh.
 - ``"scheduler"``: string indicating type of scheduler, currently ``"slurm"``, ``"pbs"`` or ``"sge"``
 - ``"commands"``: optional list(str) with commands to run at beginning of every script on system, usually for things that set up the runtime such as environment modules (e.g. ``module load vasp``)
-- ``"header"``: list(str) queuing system header lines.  Actual header is created by applying string formatting, i.e.  ``str.format(**node_dict)``, replacing substrings such as ``{num_nodes}``.
+- ``"header"``: list(str) queuing system header lines.  Actual header is created by applying string formatting, i.e.  ``str.format(**node_dict)``, replacing substrings such as ``{num_nodes}``. Normally added to default header which sets job name, max time, node number, and stdout/stderr files.
 - ``rundir``: str, optional, default ``"run_expyre"``. Place for all remote files and remote execution. 
 - ``no_default_header``: bool, optional, default ``False``. Do not put default lines (such as ``#$ -cwd`` or automatically setting the job name) to the job submission script. 
 - ``"remsh_cmd"``: optional string remote shell command, default ``"ssh"``
-- ``"no_default_header"``: bool, default false disable automatic setting of queuing system header for job name, partition/queue, max runtime, and stdout and stderr files
 - ``"rundir"``: string for a path where the remote jobs should be run
 - ``"partitions"`` or ``"queues"``: dict with partitions/queues/node-type names as keys and dict of node properties as values.
 
@@ -43,6 +43,8 @@ Available keys in ``node_dict`` which are normally used in this template:
 - ``"num_nodes"``: int total number of nodes
 - ``"num_cores"``: int total number of cores
 - ``"num_cores_per_node"``: int number of cores per node
+- ``"partition"``: name of partition (or queue), from ``partitions`` or ``queues`` dict keys,
+  of specified explicitly in corresponding value dict
 
 Note that if ``partial_node=True`` is passed to ``find_nodes`` and the total number of cores is less
 than the number per node, ``num_cores`` and ``num_cores_per_node`` are *not* rounded up to an entire node.
@@ -50,7 +52,6 @@ than the number per node, ``num_cores`` and ``num_cores_per_node`` are *not* rou
 Additional keys that are generally only used by the internally generated parts of the header:
 
 - ``"id"``: str (supposed to be guaranteed to be unique among current jobs within project) job id
-- ``"partition"`` and ``"queue"``: str partition/queue/node type
 - ``"max_time_HMS"``: str max runtime in ``hours:minutes:seconds`` format
 
 

--- a/expyre/schedulers/pbs.py
+++ b/expyre/schedulers/pbs.py
@@ -82,7 +82,6 @@ class PBS(Scheduler):
             # Make sure that first characer is alphabetic
             # Let's hope there aren't length limitations anymore
             header.append('#PBS -N N_{id}')
-            header.append('#PBS -q {partition}')
             header.append('#PBS -l walltime={max_time}')
             header.append('#PBS -o job.{id}.stdout')
             header.append('#PBS -e job.{id}.stderr')

--- a/expyre/schedulers/sge.py
+++ b/expyre/schedulers/sge.py
@@ -71,7 +71,6 @@ class SGE(Scheduler):
         if not no_default_header:
             # Make sure that first characer is alphabetic
             header.append('#$ -N N_{id}')
-            header.append('#$ -q {partition}')
             header.append('#$ -l h_rt={max_time}')
             header.append('#$ -o job.{id}.stdout')
             header.append('#$ -e job.{id}.stderr')

--- a/expyre/schedulers/slurm.py
+++ b/expyre/schedulers/slurm.py
@@ -68,7 +68,6 @@ class Slurm(Scheduler):
         header = header.copy()
         if not no_default_header:
             header.append('#SBATCH --job-name={id}')
-            header.append('#SBATCH --partition={partition}')
             header.append('#SBATCH --time={max_time}')
             header.append('#SBATCH --output=job.{id}.stdout')
             header.append('#SBATCH --error=job.{id}.stderr')

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import setuptools
 
 setuptools.setup(
     name="expyre-wfl",
-    version="0.1.1",
+    version="0.1.2",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["click>=7.0", "pandas"],
+    install_requires=["click>=7.0"],
     entry_points="""
     [console_scripts]
     xpr=expyre.cli.cli:cli


### PR DESCRIPTION
Move queueing system header's partition line (`--partition` or `-q`) from default into user-specified portion (in each system specified in `.expyre/config.json`), since some slurm systems use `--qos` as the relevant argument

Remove dependence on pandas in `xpr ls`